### PR TITLE
Report module

### DIFF
--- a/salesdataanalyzer/reporter.py
+++ b/salesdataanalyzer/reporter.py
@@ -13,14 +13,21 @@ class DataSummary(TypedDict):
 
 def write_report_file(file_name: str, data_summary: DataSummary) -> None:
     """Writes a report file in the output directory."""
-    report_text = REPORT_TEMPLATE.format(
-        customers_amount=data_summary['customers_amount'],
-        salesmen_amount=data_summary['salesmen_amount'],
-        most_expensive_sale_id=data_summary['most_expensive_sale_id'],
-        worst_salesman_name=data_summary['worst_salesman_name']
-    )
+    try:
+        report_text = REPORT_TEMPLATE.format(
+            customers_amount=data_summary['customers_amount'],
+            salesmen_amount=data_summary['salesmen_amount'],
+            most_expensive_sale_id=data_summary['most_expensive_sale_id'],
+            worst_salesman_name=data_summary['worst_salesman_name']
+        )
+    except KeyError as e:
+        raise MissingDataSummaryKeyError(f'{e.args[0]} in {data_summary}')
 
     report_file_path = OUTPUT_DIR_PATH / (file_name + REPORT_FILE_EXT)
     report_file_path.parent.mkdir(parents=True, exist_ok=True)
     with report_file_path.open(mode='w', encoding='utf-8') as report_file:
         report_file.write(report_text)
+
+
+class MissingDataSummaryKeyError(KeyError):
+    pass

--- a/salesdataanalyzer/reporter.py
+++ b/salesdataanalyzer/reporter.py
@@ -27,8 +27,12 @@ def write_report_file(file_name: str, data_summary: DataSummary) -> None:
     if contains_dir_path(file_name):
         raise FileNameContainsDirPathError(file_name)
 
+    if is_too_long(file_name):
+        raise FileNameTooLongError(file_name)
+
     report_file_path = OUTPUT_DIR_PATH / (file_name + REPORT_FILE_EXT)
     report_file_path.parent.mkdir(parents=True, exist_ok=True)
+
     with report_file_path.open(mode='w', encoding='utf-8') as report_file:
         report_file.write(report_text)
 
@@ -39,9 +43,19 @@ def contains_dir_path(file_name: str) -> bool:
     return os.path.sep in file_name
 
 
+def is_too_long(file_name: str) -> bool:
+    """Returns True if file_name concatenated with file extension
+    length is > 255. Returns False otherwise."""
+    return len(file_name + REPORT_FILE_EXT) > 255
+
+
 class MissingDataSummaryKeyError(KeyError):
     pass
 
 
 class FileNameContainsDirPathError(ValueError):
+    pass
+
+
+class FileNameTooLongError(OSError):
     pass

--- a/salesdataanalyzer/reporter.py
+++ b/salesdataanalyzer/reporter.py
@@ -12,7 +12,7 @@ class DataSummary(TypedDict):
 
 
 def write_report_file(file_name: str, data_summary: DataSummary) -> None:
-    """Write a report file in the output directory"""
+    """Writes a report file in the output directory."""
     report_text = REPORT_TEMPLATE.format(
         customers_amount=data_summary['customers_amount'],
         salesmen_amount=data_summary['salesmen_amount'],

--- a/salesdataanalyzer/reporter.py
+++ b/salesdataanalyzer/reporter.py
@@ -1,3 +1,4 @@
+import os
 from typing import TypedDict
 
 from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
@@ -23,11 +24,24 @@ def write_report_file(file_name: str, data_summary: DataSummary) -> None:
     except KeyError as e:
         raise MissingDataSummaryKeyError(f'{e.args[0]} in {data_summary}')
 
+    if contains_dir_path(file_name):
+        raise FileNameContainsDirPathError(file_name)
+
     report_file_path = OUTPUT_DIR_PATH / (file_name + REPORT_FILE_EXT)
     report_file_path.parent.mkdir(parents=True, exist_ok=True)
     with report_file_path.open(mode='w', encoding='utf-8') as report_file:
         report_file.write(report_text)
 
 
+def contains_dir_path(file_name: str) -> bool:
+    """Returns True if file_name contains OS path components separator.
+    Returns False otherwise."""
+    return os.path.sep in file_name
+
+
 class MissingDataSummaryKeyError(KeyError):
+    pass
+
+
+class FileNameContainsDirPathError(ValueError):
     pass

--- a/salesdataanalyzer/reporter.py
+++ b/salesdataanalyzer/reporter.py
@@ -1,0 +1,26 @@
+from typing import TypedDict
+
+from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
+    REPORT_TEMPLATE
+
+
+class DataSummary(TypedDict):
+    customers_amount: int
+    salesmen_amount: int
+    most_expensive_sale_id: int
+    worst_salesman_name: str
+
+
+def write_report_file(file_name: str, data_summary: DataSummary) -> None:
+    """Write a report file in the output directory"""
+    report_text = REPORT_TEMPLATE.format(
+        customers_amount=data_summary['customers_amount'],
+        salesmen_amount=data_summary['salesmen_amount'],
+        most_expensive_sale_id=data_summary['most_expensive_sale_id'],
+        worst_salesman_name=data_summary['worst_salesman_name']
+    )
+
+    report_file_path = OUTPUT_DIR_PATH / (file_name + REPORT_FILE_EXT)
+    report_file_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_file_path.open(mode='w', encoding='utf-8') as report_file:
+        report_file.write(report_text)

--- a/salesdataanalyzer/settings.py
+++ b/salesdataanalyzer/settings.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+OUTPUT_DIR_PATH = Path.home() / 'data' / 'out'
+
+REPORT_FILE_EXT = '.done.dat'
+
+REPORT_TEMPLATE = 'customers amount: {customers_amount}\n'\
+                  'salesmen amount: {salesmen_amount}\n' \
+                  'most expensive sale id: {most_expensive_sale_id}\n' \
+                  'worst salesman name: {worst_salesman_name}'

--- a/salesdataanalyzer/settings.py
+++ b/salesdataanalyzer/settings.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+INPUT_DIR_PATH = Path.home() / 'data' / 'in'
 OUTPUT_DIR_PATH = Path.home() / 'data' / 'out'
 
+INPUT_FILE_EXT = '.dat'
 REPORT_FILE_EXT = '.done.dat'
 
 REPORT_TEMPLATE = 'customers amount: {customers_amount}\n'\

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,16 @@
+import time
+from typing import Callable
+
+MAX_WAIT = 0.5
+WAIT = 0.025
+
+
+def wait_for(func: Callable[[], None]) -> None:
+    start_time = time.time()
+    while True:
+        try:
+            return func()
+        except AssertionError as e:
+            if time.time() - start_time > MAX_WAIT:
+                raise e
+            time.sleep(WAIT)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,6 +6,8 @@ WAIT = 0.025
 
 
 def wait_for(func: Callable[[], None]) -> None:
+    """Calls the received function catching AssertionError exceptions until
+    the time limit is exceeded. Raises AssertionError exception."""
     start_time = time.time()
     while True:
         try:

--- a/tests/integration/report_file_writer_test.py
+++ b/tests/integration/report_file_writer_test.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from salesdataanalyzer import reporter
 from salesdataanalyzer.reporter import MissingDataSummaryKeyError, \
-    FileNameContainsDirPathError
+    FileNameContainsDirPathError, FileNameTooLongError
 from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
     REPORT_TEMPLATE
 from tests.helper import wait_for
@@ -55,4 +55,10 @@ class WriteReportFileTest(TestCase):
         self.assertRaises(FileNameContainsDirPathError,
                           reporter.write_report_file,
                           'dir' + os.path.sep + 'file_name',
+                          DATA_SUMMARY)
+
+    def test_raise_file_name_too_long_error(self):
+        self.assertRaises(FileNameTooLongError,
+                          reporter.write_report_file,
+                          'a' * (255 - len(REPORT_FILE_EXT) + 1),
                           DATA_SUMMARY)

--- a/tests/integration/report_file_writer_test.py
+++ b/tests/integration/report_file_writer_test.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from salesdataanalyzer import reporter
+from salesdataanalyzer.reporter import MissingDataSummaryKeyError
 from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
     REPORT_TEMPLATE
 from tests.helper import wait_for
@@ -37,3 +38,13 @@ class WriteReportFileTest(TestCase):
             report_text = report_file.read()
 
         self.assertEqual(EXPECTED_REPORT_TEXT, report_text)
+
+    def test_raise_missing_data_summary_field_error(self):
+        self.assertRaises(MissingDataSummaryKeyError,
+                          reporter.write_report_file,
+                          FILE_NAME,
+                          {
+                              'customers_amount': 3,
+                              'salesmen_amount': 3,
+                              'most_expensive_sale_id': 6,
+                          })

--- a/tests/integration/report_file_writer_test.py
+++ b/tests/integration/report_file_writer_test.py
@@ -1,0 +1,52 @@
+import time
+from unittest import TestCase
+
+from salesdataanalyzer import reporter
+from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
+    REPORT_TEMPLATE
+
+MAX_WAIT = 0.5
+
+FILE_NAME = 'test_data'
+REPORT_FILE_PATH = OUTPUT_DIR_PATH / (FILE_NAME + REPORT_FILE_EXT)
+
+DATA_SUMMARY = {
+    'customers_amount': 3,
+    'salesmen_amount': 3,
+    'most_expensive_sale_id': 6,
+    'worst_salesman_name': 'David Ogilvy',
+}
+
+EXPECTED_REPORT_TEXT = REPORT_TEMPLATE.format(
+    customers_amount=DATA_SUMMARY['customers_amount'],
+    salesmen_amount=DATA_SUMMARY['salesmen_amount'],
+    most_expensive_sale_id=DATA_SUMMARY['most_expensive_sale_id'],
+    worst_salesman_name=DATA_SUMMARY['worst_salesman_name']
+)
+
+
+class WriteReportFileTest(TestCase):
+    def tearDown(self):
+        REPORT_FILE_PATH.unlink(missing_ok=True)
+
+    def test_write_report_file(self):
+        reporter.write_report_file(FILE_NAME, DATA_SUMMARY)
+
+        self.wait_for_report_file_to_be_created(REPORT_FILE_PATH)
+
+        with REPORT_FILE_PATH.open(mode='r', encoding='utf-8') as report_file:
+            report_text = report_file.read()
+
+        self.assertEqual(EXPECTED_REPORT_TEXT, report_text)
+
+    def wait_for_report_file_to_be_created(self, file_path):
+        start_time = time.time()
+        while True:
+            try:
+                self.assertTrue(file_path.exists(),
+                                "Report file wasn't created")
+                return
+            except AssertionError as e:
+                if time.time() - start_time > MAX_WAIT:
+                    raise e
+                time.sleep(0.025)

--- a/tests/integration/report_file_writer_test.py
+++ b/tests/integration/report_file_writer_test.py
@@ -1,7 +1,9 @@
+import os
 from unittest import TestCase
 
 from salesdataanalyzer import reporter
-from salesdataanalyzer.reporter import MissingDataSummaryKeyError
+from salesdataanalyzer.reporter import MissingDataSummaryKeyError, \
+    FileNameContainsDirPathError
 from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
     REPORT_TEMPLATE
 from tests.helper import wait_for
@@ -48,3 +50,9 @@ class WriteReportFileTest(TestCase):
                               'salesmen_amount': 3,
                               'most_expensive_sale_id': 6,
                           })
+
+    def test_raise_file_name_contains_dir_path_error(self):
+        self.assertRaises(FileNameContainsDirPathError,
+                          reporter.write_report_file,
+                          'dir' + os.path.sep + 'file_name',
+                          DATA_SUMMARY)

--- a/tests/integration/report_file_writer_test.py
+++ b/tests/integration/report_file_writer_test.py
@@ -1,11 +1,9 @@
-import time
 from unittest import TestCase
 
 from salesdataanalyzer import reporter
 from salesdataanalyzer.settings import OUTPUT_DIR_PATH, REPORT_FILE_EXT, \
     REPORT_TEMPLATE
-
-MAX_WAIT = 0.5
+from tests.helper import wait_for
 
 FILE_NAME = 'test_data'
 REPORT_FILE_PATH = OUTPUT_DIR_PATH / (FILE_NAME + REPORT_FILE_EXT)
@@ -32,21 +30,10 @@ class WriteReportFileTest(TestCase):
     def test_write_report_file(self):
         reporter.write_report_file(FILE_NAME, DATA_SUMMARY)
 
-        self.wait_for_report_file_to_be_created(REPORT_FILE_PATH)
+        wait_for(lambda: self.assertTrue(REPORT_FILE_PATH.exists(),
+                                         "Report file wasn't created"))
 
         with REPORT_FILE_PATH.open(mode='r', encoding='utf-8') as report_file:
             report_text = report_file.read()
 
         self.assertEqual(EXPECTED_REPORT_TEXT, report_text)
-
-    def wait_for_report_file_to_be_created(self, file_path):
-        start_time = time.time()
-        while True:
-            try:
-                self.assertTrue(file_path.exists(),
-                                "Report file wasn't created")
-                return
-            except AssertionError as e:
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                time.sleep(0.025)

--- a/tests/system/app_test.py
+++ b/tests/system/app_test.py
@@ -1,10 +1,8 @@
-import time
 from pathlib import Path
 from unittest import TestCase
 
 from salesdataanalyzer import app
-
-MAX_WAIT = 0.5
+from tests.helper import wait_for
 
 DATA_LINES = [
     '001' 'ç' '12312312312' 'ç' 'John H. Patterson' 'ç' '192000.00' '\n',
@@ -54,20 +52,10 @@ class AppTest(TestCase):
 
         app.main()
 
-        self.wait_for_report_file_to_be_created(REPORT_FILE_PATH)
+        wait_for(lambda: self.assertTrue(REPORT_FILE_PATH.exists(),
+                                         "Report file wasn't created"))
 
         with REPORT_FILE_PATH.open(mode='r', encoding='utf-8') as report_file:
             data_summary = report_file.read()
 
         self.assertEqual(EXPECTED_DATA_SUMMARY, data_summary)
-
-    def wait_for_report_file_to_be_created(self, file_path):
-        start_time = time.time()
-        while True:
-            try:
-                self.assertTrue(file_path.exists(), "Report file wasn't created")
-                return
-            except AssertionError as e:
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                time.sleep(0.025)

--- a/tests/system/app_test.py
+++ b/tests/system/app_test.py
@@ -1,7 +1,8 @@
-from pathlib import Path
 from unittest import TestCase
 
 from salesdataanalyzer import app
+from salesdataanalyzer.settings import INPUT_DIR_PATH, OUTPUT_DIR_PATH, \
+    REPORT_TEMPLATE, REPORT_FILE_EXT, INPUT_FILE_EXT
 from tests.helper import wait_for
 
 DATA_LINES = [
@@ -19,23 +20,14 @@ DATA_LINES = [
     '003' 'ç' '006' 'ç' '[06-250-98.89'  ',' '009-1115-78,69]' 'ç' 'Mary Kay Ash'      '\n',
 ]
 
-DATA_SUMMARY_TEMPLATE = 'customers amount: {customers_amount}\n'\
-                        'salesmen amount: {salesmen_amount}\n' \
-                        'most expensive sale id: {most_expensive_sale_id}\n' \
-                        'worst salesman name: {worst_salesman_name}'
-
-EXPECTED_DATA_SUMMARY = DATA_SUMMARY_TEMPLATE.format(
+EXPECTED_REPORT_TEXT = REPORT_TEMPLATE.format(
     customers_amount=3, salesmen_amount=3, most_expensive_sale_id=6,
     worst_salesman_name='David Ogilvy'
 )
 
 FILE_NAME = 'test_data'
-
-DATA_FILE_NAME = FILE_NAME + '.dat'
-REPORT_FILE_NAME = FILE_NAME + '.done.dat'
-
-DATA_FILE_PATH = Path.home() / 'data' / 'in' / DATA_FILE_NAME
-REPORT_FILE_PATH = Path.home() / 'data' / 'out' / REPORT_FILE_NAME
+DATA_FILE_PATH = INPUT_DIR_PATH / (FILE_NAME + INPUT_FILE_EXT)
+REPORT_FILE_PATH = OUTPUT_DIR_PATH / (FILE_NAME + REPORT_FILE_EXT)
 
 
 class AppTest(TestCase):
@@ -56,6 +48,6 @@ class AppTest(TestCase):
                                          "Report file wasn't created"))
 
         with REPORT_FILE_PATH.open(mode='r', encoding='utf-8') as report_file:
-            data_summary = report_file.read()
+            report_text = report_file.read()
 
-        self.assertEqual(EXPECTED_DATA_SUMMARY, data_summary)
+        self.assertEqual(EXPECTED_REPORT_TEXT, report_text)


### PR DESCRIPTION
This branch implements the Reporter system module. It basically consists of a function that receives a file name (without extension) and a dictionary containing the data to be written in the report file, and creates a new report file in the data output directory.
The file extension, the output directory and the file template are fetched from the settings file.
Besides that, there's an implementation of a generic wait-for-assertion helper function to be used for testing. The system test was rewritten to use this new function. Also, this test now fetches configurations from the settings file.